### PR TITLE
Fix compile-time warnings

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -13,7 +13,6 @@ void parse_run(xmpp_conn_t * const conn, xmpp_ctx_t *ctx, char *message, const c
 {
 	FILE *out_file;
 	char *output_buffer;
-	size_t size_read;
 	size_t output_size = 0;
 	size_t off = 0;
 

--- a/src/users.c
+++ b/src/users.c
@@ -1,5 +1,6 @@
 // vim: noexpandtab:ts=4:sts=4:sw=4
 
+#include <stdlib.h>
 #include <string.h>
 #include "users.h"
 

--- a/src/xmpp.c
+++ b/src/xmpp.c
@@ -41,12 +41,12 @@ int message_handler(xmpp_conn_t * const conn,
 	return 1;
 }
 
-void roster_handler(xmpp_conn_t * const conn,
+int roster_handler(xmpp_conn_t * const conn,
 		xmpp_stanza_t * const stanza,
 		void * const userdata)
 {
 	xmpp_stanza_t *query, *item;
-	const char *type, *name;
+	const char *type;
 
 	type = xmpp_stanza_get_type(stanza);
 	if (strcmp(type, "error") == 0)
@@ -65,6 +65,7 @@ void roster_handler(xmpp_conn_t * const conn,
 		}
 		printf("End of roster\n\n");
 	}
+	return 0;
 }
 
 void conn_handler(xmpp_conn_t * const conn,


### PR DESCRIPTION
xmpp_handler returns 'int' and libstrophe checks return value.
Therefore, a handler must not return 'void'.