### PR TITLE
Disconnect on quit

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -77,7 +77,7 @@ void parse(xmpp_conn_t * const conn, xmpp_ctx_t *ctx, char *message, const char 
 				message[4] == 't')
 		{
 			printf("Shutting down\n");
-			xmpp_stop(ctx);
+			xmpp_disconnect(conn);
 		}
 	}
 }

--- a/src/xmpp.c
+++ b/src/xmpp.c
@@ -109,7 +109,7 @@ void conn_handler(xmpp_conn_t * const conn,
 	}
 	else
 	{
-		printf("DEBUG: connection failed\n");
+		printf("DEBUG: disconnected\n");
 		xmpp_stop(ctx);
 	}
 }


### PR DESCRIPTION
Missed xmpp_disconnect() causes memory leaks, because libstrophe doesn't
free some fields of connected xmpp_conn_t object and print debug message
instead.

Proper workflow is to call xmpp_disconnect() when "!quit" received and
wait until conn_handler() receives XMPP_CONN_DISCONNECT event.